### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,11 +6,11 @@ SimpleAciUiLogServer
    :target: https://landscape.io/github/datacenter/SimpleAciUiLogServer/master
    :alt: Code Health
 
-.. image:: https://pypip.in/version/SimpleAciUiLogServer/badge.svg
+.. image:: https://img.shields.io/pypi/v/SimpleAciUiLogServer.svg
     :target: https://pypi.python.org/pypi/SimpleAciUiLogServer/
     :alt: Latest Version
 
-.. image:: https://pypip.in/wheel/SimpleAciUiLogServer/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/SimpleAciUiLogServer.svg
     :target: https://pypi.python.org/pypi/SimpleAciUiLogServer/
     :alt: Wheel Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20simpleaciuilogserver))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `simpleaciuilogserver`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.